### PR TITLE
Add check to safely remove markers

### DIFF
--- a/DrawHelper.js
+++ b/DrawHelper.js
@@ -801,7 +801,9 @@ var DrawHelper = (function() {
 
         this.startDrawing(
             function() {
-                markers.remove();
+                if (markers != null) {
+                    markers.remove();
+                }
                 mouseHandler.destroy();
                 tooltip.setVisible(false);
             }
@@ -857,7 +859,9 @@ var DrawHelper = (function() {
         this.startDrawing(
             function() {
                 primitives.remove(poly);
-                markers.remove();
+                if (markers != null) {
+                    markers.remove();
+                }
                 mouseHandler.destroy();
                 tooltip.setVisible(false);
             }
@@ -968,7 +972,9 @@ var DrawHelper = (function() {
                 if(extent != null) {
                     primitives.remove(extent);
                 }
-                markers.remove();
+                if (markers != null) {
+                    markers.remove();
+                }
                 mouseHandler.destroy();
                 tooltip.setVisible(false);
             }
@@ -1050,7 +1056,9 @@ var DrawHelper = (function() {
                 if(circle != null) {
                     primitives.remove(circle);
                 }
-                markers.remove();
+                if (markers != null) {
+                    markers.remove();
+                }
                 mouseHandler.destroy();
                 tooltip.setVisible(false);
             }


### PR DESCRIPTION
When stop editing is called right after it's been started without any
points being added to the shape markers remains null and errors when
markers.remove() is called.